### PR TITLE
backend: Add db support and minimum project level settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ pip-delete-this-directory.txt
 # Project specific configuration
 # ==============================
 .idea
+settings.py
 
 
 # =====

--- a/core.py
+++ b/core.py
@@ -14,17 +14,12 @@ Miscellaneous objects:
 
 __author__ = 'Marius Mucenicu <marius_mucenicu@yahoo.com>'
 
-# Standard library
-import logging
-
 # Third-party
 import flask
 
 # Project specific
+from knowlift import db
 from knowlift import views
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 app = flask.Flask(__name__)
 
@@ -38,3 +33,8 @@ app.add_url_rule('/result', 'result', views.result, methods=['POST'])
 
 app.register_error_handler(404, views.page_not_found)
 app.register_error_handler(500, views.internal_server_error)
+
+app.teardown_appcontext(db.close_connection)
+
+app.config.from_object('knowlift.default_settings')
+app.config.from_pyfile('knowlift/settings.py', silent=True)

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,20 +55,28 @@ Encapsulates o series of interactive games with the purpose of increasing one's 
 In order to get the project started locally, you need to go through these simple steps:
 
 ### Step 1: Prerequisites
-+ Make sure you have any version of `Python 3.6.X, 3.7.X` installed.
-    + If you **haven't got** any of the supported `Python` versions (mentioned above), you can download one from [here](https://www.python.org/).
++ Make sure you have any version of **Python 3.6.X**, **3.7.X** installed.
+    + If you **haven't got** any of the supported **Python** versions (mentioned above), you can download one from [here](https://www.python.org/).
 + Clone or download this repository locally.
-+ (OPTIONAL) Create a `Python` virtual environment (to isolate the game's package dependencies) and **activate** it.
++ [OPTIONAL]: Create a **Python** virtual environment (to isolate the game's package dependencies) and **activate** it.
 
-### Step 2: Change directory into the projct root (everything you do will be done from here)
+### Step 2: Change directory into the project root (everything you do will be done from here)
 
-### Step 3: Install package dependencies
+### Step 3: Change project settings [OPTIONAL]
++ The project starts with a default configuration found in **knowlift/default_settings.py**
+     + NOTE: This should be sufficient to run the application & the tests.
++ To alter the default configuration:
+     + Make a copy of **knowlift/default_settings.py** and rename it to **knowlift/settings.py**
+     + Override any values in the new file (**knowlift/settings.py**) as necessary.
+     + Check **knowlift/default_settings.py**'s docstring for additional information.
+
+### Step 4: Install package dependencies
 ```pip install -r requirements.txt```
 
-### Step 4: Running the tests
+### Step 5: Running the tests
 ```python -m unittest discover``` (This command should show absolutely no errors)
 
-### Step 5: Running the game
+### Step 6: Running the game
 #### On Windows:
 + Command Prompt:
     + ```set FLASK_APP=core.py```

--- a/knowlift/__init__.py
+++ b/knowlift/__init__.py
@@ -3,14 +3,17 @@ Store logic and configuration for the entire project.
 
 Modules:
 ========
+    db: Handle database related functionality.
+    default_settings: Store project level default settings (quick-start development settings).
     lexicon: Handle building sentences from a given lexicon.
     number_distance: Handle mathematical intervals scenarios.
     views: Handle HTTP requests.
 
 Notes:
 ======
-    This package is intended to bundle all of the core functionality from this application, which is
-        comprised of different interactive games, which in turn have different configurations.
+    This package is intended to bundle all of the core functionality of this application.
+    The default configuration stored in the default_settings module is intended for development
+        only and it's unsuitable for production. Check the module's docstring for more information.
 
 Miscellaneous objects:
 ======================

--- a/knowlift/db.py
+++ b/knowlift/db.py
@@ -1,0 +1,49 @@
+"""
+Store functionality that deals with the underlying database.
+
+Functions:
+==========
+    get_connection: Get or create a single DB API connection.
+    close_connection: Close the DB API connection.
+
+Miscellaneous objects:
+======================
+    Except for the public objects exported by this module and their public APIs (if applicable),
+        everything else is an implementation detail, and shouldn't be relied upon as it may change
+        over time.
+"""
+
+# Standard library
+import logging
+
+# Third-party
+import flask
+
+logger = logging.getLogger(__name__)
+
+
+def get_connection():
+    """
+    Get or create a single DB API connection checked out from the connection pool.
+
+    :return: A new Connection object.
+    :rtype: sqlalchemy.engine.base.Connection
+    """
+    if 'db' not in flask.g:
+        engine = flask.current_app.config['DATABASE_ENGINE']
+        flask.g.db = engine.connect()
+        return flask.g.db
+    else:
+        return flask.g.db
+
+
+def close_connection(exception):
+    """Return the underlying DB API connection to the connection pool."""
+    if exception:
+        logger.debug(exception)
+
+    db = getattr(flask.g, 'db', None)
+    if db is not None:
+        db.close()
+    else:
+        logger.debug('The database does not exist on the application context.')

--- a/knowlift/default_settings.py
+++ b/knowlift/default_settings.py
@@ -1,0 +1,47 @@
+"""
+Store the configuration necessary to start the application.
+
+CONSTANTS
+=========
+    BASE_DIR: Absolute path to the project root on the filesystem.
+    DATABASE: Absolute path to the database on the filesystem.
+    DATABASE_ENGINE: A mechanism used to interact with the database.
+    SECRET_KEY: A value used to create a signature string (used to sign Cookies).
+
+Notes
+=====
+    These settings need to be available when the application starts up.
+    The application loads the necessary configuration from 2 objects, as follows:
+        1. This module (which holds the default settings), and is added to the version control.
+        2. A module called settings.py (if it exists), which is not added to the version control.
+
+        The purpose of the settings.py is to hold environment specific settings, such as:
+            * production settings
+            * staging settings
+            * development settings
+
+        The process of overriding any values found in this module, is a 2-step process, as follows:
+            1. A copy of this file should be made and renamed to settings.py
+            2. Override the values as necessary (in settings.py)
+
+Miscellaneous objects:
+======================
+    Except for the public objects exported by this module and their public APIs (if applicable),
+        everything else is an implementation detail, and shouldn't be relied upon as it may change
+        over time.
+"""
+
+# Standard library
+import os
+
+# Third-party
+import sqlalchemy
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DATABASE = os.path.join(BASE_DIR, 'default.db')
+DATABASE_ENGINE = sqlalchemy.create_engine(f'sqlite:///{DATABASE}')
+
+# SECURITY WARNING: Set the secret key to some random bytes. Keep this really secret in production!
+SECRET_KEY = '8bc5150c3f107d9ef1f4b7d1aec03a3721e374d1a992e3cce2d8e57f7338288f'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ codecov==2.0.15
 flake8==3.7.7
 flask==1.0.2
 pylint==2.3.1
+SQLAlchemy==1.3.2


### PR DESCRIPTION
- Added SQLAlchemy SQL Toolkit (set of tools for working with databases and Python)
- Added SQLITE3 db as the main db for this project
- Added default project settings and a way to override them with production/development settings when necessary.

Resolves #153