### PR TITLE
backend: Add logging configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,11 +59,12 @@ knowlift/static/bootstrap/**/bootstrap.*
 !knowlift/static/bootstrap/**/bootstrap.min.*
 
 
-# ==============
-# Installer logs
-# ==============
+# ====
+# Logs
+# ====
 pip-log.txt
 pip-delete-this-directory.txt
+*.log
 
 
 # ====================

--- a/knowlift/__init__.py
+++ b/knowlift/__init__.py
@@ -26,6 +26,9 @@ Miscellaneous objects:
         over time.
 """
 
+# Standard Library
+from logging import config
+
 # Third-party
 import flask
 
@@ -57,6 +60,7 @@ def create_app(config_filename):
     app.register_error_handler(500, views.internal_server_error)
 
     app.teardown_appcontext(db.close_connection)
-
     app.config.from_pyfile(config_filename)
+
+    config.dictConfig(app.config['LOGGING_CONFIG'])
     return app

--- a/knowlift/default_settings.py
+++ b/knowlift/default_settings.py
@@ -1,11 +1,17 @@
 """
 Store the configuration necessary to start the application.
 
+Classes:
+========
+    ConsoleFilter: Filter out LogRecords whose levels are > logging.WARNING
+    FileFilter: Filter out LogRecords whose levels are < logging.ERROR
+
 CONSTANTS
 =========
     BASE_DIR: Absolute path to the project root on the filesystem.
     DATABASE: Absolute path to the database on the filesystem.
     DATABASE_ENGINE: A mechanism used to interact with the database.
+    LOGGING_CONF: Initial configuration for the logging machinery.
     SECRET_KEY: A value used to create a signature string (used to sign Cookies).
 
 Notes
@@ -38,6 +44,7 @@ Miscellaneous objects:
 """
 
 # Standard library
+import logging
 import os
 
 # Third-party
@@ -51,3 +58,62 @@ DATABASE_ENGINE = sqlalchemy.create_engine(f'sqlite:///{DATABASE}')
 
 # SECURITY WARNING: Set the secret key to some random bytes. Keep this really secret in production!
 SECRET_KEY = '8bc5150c3f107d9ef1f4b7d1aec03a3721e374d1a992e3cce2d8e57f7338288f'
+
+
+class ConsoleFilter:
+    """Allow only LogRecords whose severity levels are either DEBUG, INFO or WARNING."""
+
+    def __call__(self, log):
+        if log.levelno in (logging.DEBUG, logging.INFO, logging.WARNING):
+            return 1
+        else:
+            return 0
+
+
+class FileFilter:
+    """Allow only LogRecords whose severity levels are either ERROR or CRITICAL."""
+
+    def __call__(self, log):
+        if log.levelno in (logging.ERROR, logging.CRITICAL):
+            return 1
+        else:
+            return 0
+
+
+LOGGING_CONFIG = {
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': f'[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        }
+    },
+    'filters': {
+        'file_filter': {
+            '()': FileFilter,
+        },
+        'console_filter': {
+            '()': ConsoleFilter,
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+            'filters': ['console_filter'],
+        },
+        'file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'default',
+            'filename': 'errors.log',
+            'filters': ['file_filter'],
+            'maxBytes': 500 * 1024 * 1024,
+            'backupCount': 1,
+        },
+    },
+    'loggers': {
+        'knowlift': {
+            'level': 'DEBUG',
+            'handlers': ['console', 'file'],
+        }
+    },
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,3 +13,9 @@ Miscellaneous objects:
         everything else is an implementation detail, and shouldn't be relied upon as it may change
         over time.
 """
+
+# Standard library
+import logging
+
+# TODO(Marius): Remove the level argument once you drop support for Python 3.6
+logging.disable(level=logging.CRITICAL)  # Keep the console clean during tests

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -197,7 +197,6 @@ class LexiconTest(unittest.TestCase):
             make_string(words, number): {make_string(words, number)}
             for number in range(32)
         }
-        print(valid_number_keys32)
         invalid_number_keys65 = {
             make_string(words, number): {make_string(words, number)}
             for number in range(65)


### PR DESCRIPTION
- Added files that end with the .log (*.log) extension to .gitignore
- Disabled logging in tests to keep the console clean
- LogRecords whose severity levels are up to and including WARNING are
  printed out to console.
- LogRecords whose severity levels are at least ERROR and upwards are
  stored to a file which grows to a maximum size of 500 MiB, then it gets
  rotated with another file which grows to the same size. When the second
  file reaches the limit, the first file is discarded and the second now
  takes its place while a new one is being logged to. So there will always
  be a rotation of 2 files of 500 MiB which will store ERROR and CRITICAL
  logs.

Resolves #157