### PR TITLE
refactor: Improve the way settings are used

### DIFF
--- a/knowlift/__init__.py
+++ b/knowlift/__init__.py
@@ -16,8 +16,8 @@ Modules:
 Notes:
 ======
     This package is intended to bundle all of the core functionality of this application.
-    The default configuration stored in the default_settings module is intended for development
-        only and it's unsuitable for production. Check the module's docstring for more information.
+    The default configuration stored in default_settings.py is intended for development only and
+        it's unsuitable for production. Check the module's docstring for more information.
 
 Miscellaneous objects:
 ======================

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -5,7 +5,6 @@ CONSTANTS:
 ==========
     HTTP_CLIENT: A Python class that acts as a dummy Web browser, allowing you to test your views.
     TEST_APPLICATION: A Python class which implements a WSGI application and acts as a central obj.
-    TEST_CONFIG: The full path to the default configuration.
 
 Functions:
 ==========
@@ -26,7 +25,6 @@ Classes:
 
 # Standard library
 import json
-import os
 import unittest
 
 # Project specific
@@ -34,8 +32,7 @@ import knowlift
 
 from knowlift import default_settings
 
-TEST_CONFIG = os.path.join(default_settings.BASE_DIR, 'knowlift', 'default_settings.py')
-TEST_APPLICATION = knowlift.create_app(TEST_CONFIG)
+TEST_APPLICATION = knowlift.create_app(default_settings.__file__)
 HTTP_CLIENT = TEST_APPLICATION.test_client()
 
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,12 +4,8 @@ Kick off the web application.
 Notes:
 ======
     This file contains the code mod_wsgi is executing on startup to get the application object.
-    The module CONFIG_PATH points to doesn't exist by default and needs to be created before
-        running the application. For details check knowlift/default_settings.py's docstring.
-
-CONSTANTS:
-==========
-    CONFIG_PATH: The full path to the configuration module.
+    The module settings.py doesn't exist by default and needs to be created before running the
+        application. For details check knowlift/default_settings.py's docstring.
 
 Global variables:
 =================
@@ -24,13 +20,9 @@ Miscellaneous objects:
 
 __author__ = 'Marius Mucenicu <marius_mucenicu@yahoo.com>'
 
-# Standard library
-import os
-
 # Project specific
 import knowlift
 
-from knowlift import default_settings
+from knowlift import settings
 
-CONFIG_PATH = os.path.join(default_settings.BASE_DIR, 'knowlift', 'settings.py')
-application = knowlift.create_app(CONFIG_PATH)
+application = knowlift.create_app(settings.__file__)


### PR DESCRIPTION
- Use production settings directly as though it were created instead of
  deriving it from default_settings
- Use the default_settings directly in tests (instead of building it's
  path)

Resolves #165