### PR TITLE
Use development as default config if not set

### DIFF
--- a/src/knowlift/core/settings.py
+++ b/src/knowlift/core/settings.py
@@ -27,7 +27,7 @@ Notes
 * There is a different configuration for each environment: prod, dev, test.
 * The environments above tell Flask which context the app is running in.
 * To switch between environments (configurations) set the KNOWLIFT_ENV env.
-* If KNOWLIFT_ENV is not set, the default config used will be production.
+* If KNOWLIFT_ENV is not set, the default config used will be development.
 * Do not alter settings in the application at runtime.
 """
 
@@ -176,4 +176,4 @@ def get_config(name):
     :return: Configuration instance for the specified environment.
     :rtype: Config
     """
-    return CONFIGS.get(name.strip().lower(), CONFIGS['production'])
+    return CONFIGS.get(name.strip().lower(), CONFIGS['development'])

--- a/src/knowlift/web/__init__.py
+++ b/src/knowlift/web/__init__.py
@@ -51,7 +51,6 @@ def create_app(env=None):
         3. Prefixed environment variables (KNOWLIFT_*) — highest precedence
 
     :param env: Environment name ('development', 'production', or 'test').
-                If None, uses KNOWLIFT_ENV or defaults to 'production'.
     :type env: str or None
     :return: The Flask WSGI application instance.
     :rtype: flask.app.Flask
@@ -63,7 +62,7 @@ def create_app(env=None):
         static_folder=os.path.join(os.path.dirname(__file__), 'static')
     )
 
-    app_environment = env or os.getenv('KNOWLIFT_ENV', 'production')
+    app_environment = env or os.getenv('KNOWLIFT_ENV')
     app_config = settings.get_config(app_environment)
 
     app.config.from_object(app_config)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -185,6 +185,6 @@ class GetConfigFunctionTests(unittest.TestCase):
         self.assertIsInstance(config, settings.DevelopmentConfig)
 
     def test_get_config_default_fallback(self):
-        """Verify get_config returns ProductionConfig for unknown environments."""
+        """Verify get_config returns DevelopmentConfig for unknown environments."""
         config = settings.get_config('unknown')
-        self.assertIsInstance(config, settings.ProductionConfig)
+        self.assertIsInstance(config, settings.DevelopmentConfig)


### PR DESCRIPTION
Resolves #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - When no environment is specified or recognized, the app now defaults to Development settings, improving safety for local runs and reducing accidental use of production configuration.
- Documentation
  - Updated environment behavior descriptions to reflect the new Development default.
- Tests
  - Updated tests to validate Development as the fallback environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->