### PR TITLE
Split the project dependencies into prod/dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,15 @@ version = "2.0.0"
 description = "Interactive games designed to enhance cognitive skills"
 readme = "docs/README.md"
 requires-python = ">=3.11,<3.14"
+
 dependencies = [
-    "coverage==7.10.3",
     "flask==3.1.1",
     "sqlalchemy==2.0.42",
+]
+
+[dependency-groups]
+dev = [
+    "coverage==7.10.3",
     "ruff==0.12.9",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -163,18 +163,26 @@ name = "knowlift"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "coverage" },
     { name = "flask" },
-    { name = "ruff" },
     { name = "sqlalchemy" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "coverage" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "coverage", specifier = "==7.10.3" },
     { name = "flask", specifier = "==3.1.1" },
-    { name = "ruff", specifier = "==0.12.9" },
     { name = "sqlalchemy", specifier = "==2.0.42" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage", specifier = "==7.10.3" },
+    { name = "ruff", specifier = "==0.12.9" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reclassified certain tools as development-only dependencies and introduced a dedicated development dependency group.
  * Reduced the runtime dependency set to only core libraries, streamlining production installations.
  * Ensures tooling is installed only in development environments, keeping production environments lean.
  * No user-facing changes; functionality and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->